### PR TITLE
fix: floor selector height change only on mobile

### DIFF
--- a/src/controls/floorControl/floorControl.ts
+++ b/src/controls/floorControl/floorControl.ts
@@ -101,7 +101,7 @@ export class FloorControl {
       margins.top = 0
     }
 
-    if (this._map.getSelected()) {
+    if ($(this._map._container).hasClass(uiConfig.SMALL_SCREEN_CLASS) && this._map.getSelected()) {
       footerHeight = $(this._map._container).find('#mwz-footer-selection').height()
     }
 

--- a/src/footer/selection/selection.ts
+++ b/src/footer/selection/selection.ts
@@ -58,6 +58,10 @@ export class FooterSelection extends DefaultControl {
     } else {
       this.initializeMapBoxControls()
       this.map.setPromotedPlaces([])
+
+      if (this.map.floorControl) {
+        this.map.floorControl.resize()
+      }
     }
     return Promise.resolve()
   }


### PR DESCRIPTION
fix: floor selector height correctly reseted when unselect element